### PR TITLE
reenable arm64 docker builds in workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -65,7 +65,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          # platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Uncomments the platforms line in docker-image.yml to re-enable multi-architecture Docker builds for both linux/amd64 and linux/arm64.
This was previously commented out, limiting builds to amd64 only.